### PR TITLE
Allow StaticConnections being configures also with degree values

### DIFF
--- a/roboticsapi.core/src/org/roboticsapi/world/StaticConnection.java
+++ b/roboticsapi.core/src/org/roboticsapi/world/StaticConnection.java
@@ -263,6 +263,21 @@ public class StaticConnection extends Connection {
 		return z;
 	}
 
+	@ConfigurationProperty(Optional = true)
+	public void setADeg(double aDeg) {
+		this.setA(Math.toRadians(aDeg));
+	}
+
+	@ConfigurationProperty(Optional = true)
+	public void setBDeg(double bDeg) {
+		this.setB(Math.toRadians(bDeg));
+	}
+
+	@ConfigurationProperty(Optional = true)
+	public void setCDeg(double cDeg) {
+		this.setC(Math.toRadians(cDeg));
+	}
+
 	@Override
 	protected void validateConfigurationProperties() throws ConfigurationException {
 		super.validateConfigurationProperties();


### PR DESCRIPTION
Allow StaticConnections being configured using degree values for orientation A,B,C using parameters aDeg, bDeg and cDeg in configuration files. This allows for an easier usage for example of a base coordinate system measured using an industrial robot with traditional robot controller software.