### PR TITLE
Fix RMI visualization

### DIFF
--- a/roboticsapi.visualization/src/main/java/org/roboticsapi/feature/visualization/connector/VisualizationGraph.java
+++ b/roboticsapi.visualization/src/main/java/org/roboticsapi/feature/visualization/connector/VisualizationGraph.java
@@ -116,6 +116,7 @@ public class VisualizationGraph implements RoboticsObjectListener {
 				return;
 			r.run();
 		} catch (Exception e) {
+			RAPILogger.logException(this.getClass(), e);
 			failed = true;
 		}
 	}

--- a/roboticsapi.visualization/src/main/java/org/roboticsapi/feature/visualization/rmi/RmiVisualizationClientScene.java
+++ b/roboticsapi.visualization/src/main/java/org/roboticsapi/feature/visualization/rmi/RmiVisualizationClientScene.java
@@ -82,4 +82,7 @@ public interface RmiVisualizationClientScene extends VisualizationClientScene, R
 	@Override
 	void setScale(int id, double sx, double sy, double sz) throws RemoteException;
 
+	@Override
+	int getRootFrame() throws Exception;
+
 }


### PR DESCRIPTION
Added methods of a RMI remote interface as implicit overrides, as they are otherwise not considered as serializable methods in some Java versions. This bug might have caused empty robot cells in visualizations connected over RMI.