### PR TITLE
Feature: ActivityScheduler to "forget" previous acivity results

### DIFF
--- a/roboticsapi.core/src/main/java/org/roboticsapi/core/activity/ActivityScheduler.java
+++ b/roboticsapi.core/src/main/java/org/roboticsapi/core/activity/ActivityScheduler.java
@@ -35,13 +35,17 @@ public class ActivityScheduler {
 	}
 
 	public void cancel(Actuator device) throws RoboticsException {
-		if (handles.containsKey(device))
-			handles.get(device).cancelExecute();
+		ActivityHandle h = handles.get(device);
+		if (h != null) {
+			h.cancelExecute();
+		}
 	}
 
 	public void endExecute(Actuator device) throws RoboticsException {
-		if (handles.containsKey(device))
-			handles.get(device).endExecute();
+		ActivityHandle h = handles.get(device);
+		if (h != null) {
+			h.endExecute();
+		}
 	}
 
 }


### PR DESCRIPTION
ActivityScheduler can now handle devices that do have an entry in the result memory of foregoing activities even if it is unknown (null).

When mixing usage of activities and commands directly (which is no good style by the way), the activity memory does not get updated after command executions. Now, the activity memory can explicitly be set to unknown by the introduced functionality. By invoking setResults for a device with null parameters, the scheduler is provoked to "forget" the result of the foregoing activity of that device.